### PR TITLE
Fix buttonStyle BitcoinPlain background, use .clear

### DIFF
--- a/Sources/BitcoinUI/ButtonStyles.swift
+++ b/Sources/BitcoinUI/ButtonStyles.swift
@@ -199,13 +199,10 @@ public struct BitcoinPlain: ButtonStyle {
             .font(Font.body.bold())
             .padding()
             .frame(width: width, height: height)
-            .background(stateBackgroundColor())
+            .background(Color.clear)
             .foregroundColor(stateTextColor())
             .scaleEffect(configuration.isPressed ? 0.95 : 1)
             .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
-    }
-    private func stateBackgroundColor() -> Color {
-        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
     }
     private func stateBorderColor(configuration: Configuration) -> Color {
         return isEnabled


### PR DESCRIPTION
Now uses Color.clear for background.

Previous use of white and black depending on light or dark mode was not a good idea as it can leave unsightly color blocks as background when not expected.