### PR TITLE
WordCapsule: Fix alignment of numbers

### DIFF
--- a/Sources/BitcoinUI/SeedPhraseView.swift
+++ b/Sources/BitcoinUI/SeedPhraseView.swift
@@ -110,7 +110,7 @@ struct WordCapsule: View {
             Text("\(index + 1)")
                 .font(.system(size: 14))
                 .foregroundColor(.secondary)
-                .frame(minWidth: 20, alignment: .leading)
+                .frame(minWidth: 20, alignment: .trailing)
             Divider()
                 .frame(height: 20)
                 .background(Color.secondary.opacity(0.2))


### PR DESCRIPTION
Make sure that the capsules look like:

` 9 | govern`
`10 | oval`

rather than


`9  | govern`
`10 | oval`
